### PR TITLE
参加前の過去メッセージ一覧の取得機能を追加

### DIFF
--- a/chatapp/socket_event/index.js
+++ b/chatapp/socket_event/index.js
@@ -1,4 +1,5 @@
 const clients = new Map()
+const messages = []
 
 export default (io, socket) => {
   const updateParticipants = () => {
@@ -23,6 +24,8 @@ export default (io, socket) => {
 
   // 投稿メッセージを送信する
   socket.on("publishEvent", (data) => {
+    messages.unshift(data)
+    console.log(messages)
     io.sockets.emit("publishEvent", data)
   })
 
@@ -31,5 +34,9 @@ export default (io, socket) => {
     clients.delete(socket.id)
     updateParticipants()
     console.log(reason)
+  })
+
+  socket.on("getMessages", (data) => {
+    socket.emit("getMessages", messages)
   })
 }

--- a/chatapp/src/components/Chat.vue
+++ b/chatapp/src/components/Chat.vue
@@ -84,6 +84,14 @@ const onReceivePublish = (data) => {
 const onReceiveUpdateParticipants = (data) => {
   participants.value = data
 }
+
+// 過去メッセージを取得
+const onGetMessages = (data) => {
+  data.forEach(function(element, index, array) {
+    const message = Object.assign(new Message(), element)
+    chatList.push(message.user + "さん: " + message.text)
+  })
+}
 // #endregion
 
 // #region local methods
@@ -108,8 +116,13 @@ const registerSocketEvent = () => {
   socket.on("updateParticipants", (data) => {
     onReceiveUpdateParticipants(data);
   })
+
+  socket.on("getMessages", (data) => {
+    onGetMessages(data)
+  })
 }
 // #endregion
+socket.emit("getMessages", "")
 </script>
 
 <template>


### PR DESCRIPTION
socket_event/index.js側で、チャット履歴を保持し、その履歴を参加時に共有することで、チャット履歴の復元ができるようにしました